### PR TITLE
Allowing clearing the value

### DIFF
--- a/src/app/material-timepicker/directives/ngx-timepicker.directive.ts
+++ b/src/app/material-timepicker/directives/ngx-timepicker.directive.ts
@@ -90,7 +90,7 @@ export class TimepickerDirective implements ControlValueAccessor, OnDestroy, OnC
         this._max = value;
     }
 
-    private _value: string;
+    private _value = '';
 
     get value(): string {
         return this._value;
@@ -99,6 +99,8 @@ export class TimepickerDirective implements ControlValueAccessor, OnDestroy, OnC
     @Input()
     set value(value: string) {
         if (!value) {
+            this._value = ''
+            this.updateInputValue()
             return;
         }
         this._value = TimeAdapter.formatTime(value, this._format);


### PR DESCRIPTION
When I set the value of the input field that is bound to a time picker to "" I expect the field to be cleared of it's current value, rather than the input continuing to show the previous value, out of sync with the field on the view model.

**Reproduction:**
```Typescript
import {Component} from '@angular/core';

@Component({
    selector: 'app-issue-clearing-value',
    template: `
        <form>
            <input placeholder="Time"
                   name="time"
                   required
                   [ngxTimepicker]="timePicker"
                   [format]="24"
                   [(ngModel)]="viewModelField"/>

            <ngx-material-timepicker #timePicker></ngx-material-timepicker>

            <br/>

            <button type="button" (click)="clearViewModelField()">Clear underlying field</button>
            <button type="button" (click)="setViewModelField()">Set underlying field</button>

            <p>Current viewModelField value:</p>
            <p>{{viewModelField}}</p>
        </form>
    `
})
export class IssueClearingValueComponent {

    viewModelField = '18:00';

    constructor() {
    }

    clearViewModelField() {
        this.viewModelField = '';
    }

    setViewModelField() {
        this.viewModelField = '15:00';
    }
}
```