### PR TITLE
Add type='button' to timepicker period buttons

### DIFF
--- a/src/app/material-timepicker/components/timepicker-period/ngx-material-timepicker-period.component.html
+++ b/src/app/material-timepicker/components/timepicker-period/ngx-material-timepicker-period.component.html
@@ -1,10 +1,12 @@
 <div class="timepicker-period">
 			<button class="timepicker-dial__item timepicker-period__btn"
                   [ngClass]="{'timepicker-dial__item_active': selectedPeriod === timePeriod.AM}"
-                  (click)="changePeriod(timePeriod.AM)">AM</button>
+                  (click)="changePeriod(timePeriod.AM)"
+                  type="button">AM</button>
     <button class="timepicker-dial__item timepicker-period__btn"
           [ngClass]="{'timepicker-dial__item_active': selectedPeriod === timePeriod.PM}"
-          (click)="changePeriod(timePeriod.PM)">PM</button>
+          (click)="changePeriod(timePeriod.PM)"
+          type="button">PM</button>
     <div class="timepicker-period__warning" [@scaleInOut] (@scaleInOut.done)="animationDone()" *ngIf="!isPeriodAvailable">
         <p>Current time would be invalid in this period.</p>
     </div>


### PR DESCRIPTION
- Add button type to timepicker period buttons so forms are not submitted by virtue of selecting AM or PM.

I bumped into this minor issue setting up your timepicker component today, and was wondering if this was a change you might be willing to add.