### PR TITLE
xs-media quieries to support lower resolution iPhone 6 and 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Selector: `ngxTimepicker`
   max: string or DateTime | Set max time for timepicker (`11:15 pm` ) |
 | @Input()
   disableClick: boolean | Set `true` to disable opening timepicker by clicking on the input |
-
+| @Input()
+  reverseButtonOrder: boolean | Set `true` to reverse the order of the buttons (i.e. OK Cancel) |
   
 **NgxMaterialTimepickerComponent**
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -4,10 +4,11 @@
         <a class="github-link" href="https://github.com/Agranom/ngx-material-timepicker.git">
             <!--suppress HtmlUnknownAttribute -->
             <svg aria-labelledby="simpleicons-github-icon" role="img" viewBox="0 0 24 24"
-                 xmlns="http://www.w3.org/2000/svg"><title id="simpleicons-github-icon">GitHub icon</title>
+                 xmlns="http://www.w3.org/2000/svg">
+                <title id="simpleicons-github-icon">GitHub icon</title>
                 <!--suppress CheckEmptyScriptTag -->
                 <path fill="#ffffff"
-                      d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/>
+                      d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
             </svg>
 
         </a>
@@ -49,10 +50,15 @@
                         <ngx-material-timepicker #defaultTime [defaultTime]="'11:11 pm'"></ngx-material-timepicker>
                     </div>
                     <div
-                        class="ngx-material-timepicker-example__form-group ngx-material-timepicker-example__form-group--disabled">
+                         class="ngx-material-timepicker-example__form-group ngx-material-timepicker-example__form-group--disabled">
                         <input placeholder="Disabled Time Picker" aria-label="disabled time picker"
                                [ngxTimepicker]="disabled" [disabled]="true">
                         <ngx-material-timepicker #disabled></ngx-material-timepicker>
+                    </div>
+                    <div class="ngx-material-timepicker-example__form-group">
+                        <input placeholder="Reverse Button Order" aria-label="12hr format"
+                               [ngxTimepicker]="reversePicker" readonly>
+                        <ngx-material-timepicker #reversePicker [reverseButtonOrder]="true"></ngx-material-timepicker>
                     </div>
                 </div>
             </section>
@@ -90,7 +96,7 @@
                         Provide you to open the timepicker by button.
                     </p>
                     <div
-                        class="ngx-material-timepicker-example__form-group ngx-material-timepicker-example__form-group--toggled">
+                         class="ngx-material-timepicker-example__form-group ngx-material-timepicker-example__form-group--toggled">
                         <!--suppress HtmlFormInputWithoutLabel -->
                         <input [ngxTimepicker]="toggleTimepicker" [disableClick]="true" readonly>
                         <ngx-material-timepicker-toggle [for]="toggleTimepicker"></ngx-material-timepicker-toggle>
@@ -100,7 +106,7 @@
                         Provide an custom icon to the toggle button.
                     </p>
                     <div
-                        class="ngx-material-timepicker-example__form-group ngx-material-timepicker-example__form-group--toggled">
+                         class="ngx-material-timepicker-example__form-group ngx-material-timepicker-example__form-group--toggled">
                         <input placeholder="Toggle button"
                                [ngxTimepicker]="toggleIcon" [disableClick]="true" readonly>
                         <ngx-material-timepicker-toggle [for]="toggleIcon">
@@ -109,13 +115,13 @@
                                  ngxMaterialTimepickerToggleIcon>
                                 <!--suppress CheckEmptyScriptTag -->
                                 <path
-                                    d="M15,3C8.373,3,3,8.373,3,15c0,6.627,5.373,12,12,12s12-5.373,12-12C27,8.373,21.627,3,15,3z M16,16H7.995 C7.445,16,7,15.555,7,15.005v-0.011C7,14.445,7.445,14,7.995,14H14V5.995C14,5.445,14.445,5,14.995,5h0.011 C15.555,5,16,5.445,16,5.995V16z"/>
+                                      d="M15,3C8.373,3,3,8.373,3,15c0,6.627,5.373,12,12,12s12-5.373,12-12C27,8.373,21.627,3,15,3z M16,16H7.995 C7.445,16,7,15.555,7,15.005v-0.011C7,14.445,7.445,14,7.995,14H14V5.995C14,5.445,14.445,5,14.995,5h0.011 C15.555,5,16,5.445,16,5.995V16z" />
                             </svg>
                         </ngx-material-timepicker-toggle>
                         <ngx-material-timepicker #toggleIcon></ngx-material-timepicker>
                     </div>
                     <div
-                        class="ngx-material-timepicker-example__form-group ngx-material-timepicker-example__form-group--toggled">
+                         class="ngx-material-timepicker-example__form-group ngx-material-timepicker-example__form-group--toggled">
                         <input placeholder="Toggle button (disabled)"
                                [ngxTimepicker]="toggleTimepickerDisabled" [disableClick]="true" readonly>
                         <ngx-material-timepicker-toggle [for]="toggleTimepickerDisabled"
@@ -205,7 +211,7 @@
                 <app-example-source-code [sourceCode]="controlSimpleSettings">Simple examples</app-example-source-code>
                 <div class="ngx-material-timepicker-example__body">
                     <p class="ngx-material-timepicker-example__description">
-                            Simple settings
+                        Simple settings
                     </p>
                     <div class="ngx-material-timepicker-example__form-group">
                         <ngx-timepicker-field [defaultTime]="'11:11 am'"></ngx-timepicker-field>
@@ -234,7 +240,8 @@
                         <ngx-timepicker-field [toggleIcon]="icon"></ngx-timepicker-field>
                         <ng-template #icon>
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30" width="30px" height="30px">
-                                <path d="M15,3C8.373,3,3,8.373,3,15c0,6.627,5.373,12,12,12s12-5.373,12-12C27,8.373,21.627,3,15,3z M16,16H7.995 C7.445,16,7,15.555,7,15.005v-0.011C7,14.445,7.445,14,7.995,14H14V5.995C14,5.445,14.445,5,14.995,5h0.011 C15.555,5,16,5.445,16,5.995V16z"/>
+                                <path
+                                      d="M15,3C8.373,3,3,8.373,3,15c0,6.627,5.373,12,12,12s12-5.373,12-12C27,8.373,21.627,3,15,3z M16,16H7.995 C7.445,16,7,15.555,7,15.005v-0.011C7,14.445,7.445,14,7.995,14H14V5.995C14,5.445,14.445,5,14.995,5h0.011 C15.555,5,16,5.445,16,5.995V16z" />
                             </svg>
                         </ng-template>
                     </div>

--- a/src/app/material-timepicker/components/timepicker-button/ngx-material-timepicker-button.component.html
+++ b/src/app/material-timepicker/components/timepicker-button/ngx-material-timepicker-button.component.html
@@ -1,3 +1,5 @@
-<button class="timepicker-button" type="button">
-  <span><ng-content></ng-content></span>
+<button class="timepicker-button" [ngClass]="'timepicker-button__' + identifier" type="button">
+  <span>
+    <ng-content></ng-content>
+  </span>
 </button>

--- a/src/app/material-timepicker/components/timepicker-button/ngx-material-timepicker-button.component.ts
+++ b/src/app/material-timepicker/components/timepicker-button/ngx-material-timepicker-button.component.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import { Component, Input } from '@angular/core';
 
 @Component({
     selector: 'ngx-material-timepicker-button',
@@ -6,4 +6,7 @@ import {Component} from '@angular/core';
     styleUrls: ['./ngx-material-timepicker-button.component.scss']
 })
 export class NgxMaterialTimepickerButtonComponent {
+
+    @Input() identifier: string;
+
 }

--- a/src/app/material-timepicker/components/timepicker-face/ngx-material-timepicker-face.component.scss
+++ b/src/app/material-timepicker/components/timepicker-face/ngx-material-timepicker-face.component.scss
@@ -59,7 +59,7 @@
         font-weight: 500;
         font-family: $primary-font-family;
         @supports (font-family: var(--primary-font-family)) {
-            font-family: var(--primary-font-family)
+            font-family: var(--primary-font-family);
         }
         &.active {
             background-color: $clock-hand-color;
@@ -90,7 +90,7 @@
         background-color: var(--clock-hand-color);
     }
     &:after {
-        content: '';
+        content: "";
         width: 7px;
         height: 7px;
         border-radius: 50%;
@@ -102,7 +102,7 @@
 }
 
 .clock-face__clock-hand_minute:before {
-    content: '';
+    content: "";
     width: 7px;
     height: 7px;
     background-color: #fff;
@@ -133,5 +133,23 @@
 
     .clock-face__clock-hand_minute:before {
         top: 0;
+    }
+}
+
+// xs-breakpoint to fit iPhone 6 & 7
+@media (max-width: 599px) and (orientation: portrait) {
+    .clock-face {
+        width: 240px;
+        height: 240px;
+    }
+    .clock-face__number {
+        &--outer {
+            height: calc(240px / 2 - 20px);
+        }
+    }
+
+    .clock-face__clock-hand {
+        height: 83px;
+        top: calc(50% - 83px);
     }
 }

--- a/src/app/material-timepicker/ngx-material-timepicker.component.html
+++ b/src/app/material-timepicker/ngx-material-timepicker.component.html
@@ -12,8 +12,8 @@
                                           (periodChanged)="changePeriod($event)"
                                           (timeUnitChanged)="changeTimeUnit($event)"
                                           (hourChanged)="onHourChange($event)"
-                                          (minuteChanged)="onMinuteChange($event)"
-            ></ngx-material-timepicker-dial>
+                                          (minuteChanged)="onMinuteChange($event)">
+            </ngx-material-timepicker-dial>
         </header>
         <div class="timepicker__main-content">
             <div class="timepicker__body" [ngSwitch]="activeTimeUnit">
@@ -27,12 +27,12 @@
                                                            (hourSelected)="onHourSelected($event)"></ngx-material-timepicker-24-hours-face>
                     <ng-template #ampmHours>
                         <ngx-material-timepicker-12-hours-face
-                            (hourChange)="onHourChange($event)"
-                            [selectedHour]="selectedHour"
-                            [period]="selectedPeriod"
-                            [minTime]="minTime"
-                            [maxTime]="maxTime"
-                            (hourSelected)="onHourSelected($event)"></ngx-material-timepicker-12-hours-face>
+                                                               (hourChange)="onHourChange($event)"
+                                                               [selectedHour]="selectedHour"
+                                                               [period]="selectedPeriod"
+                                                               [minTime]="minTime"
+                                                               [maxTime]="maxTime"
+                                                               (hourSelected)="onHourSelected($event)"></ngx-material-timepicker-12-hours-face>
                     </ng-template>
                 </div>
                 <ngx-material-timepicker-minutes-face *ngSwitchCase="timeUnit.MINUTE"
@@ -46,22 +46,25 @@
                                                       (minuteChange)="onMinuteChange($event)"></ngx-material-timepicker-minutes-face>
             </div>
             <div class="timepicker__actions">
-                <div (click)="close()">
+                <div (click)="close()" *ngIf="!reverseButtonOrder">
                     <!--suppress HtmlUnknownAttribute -->
                     <ng-container *ngTemplateOutlet="cancelBtnTmpl ? cancelBtnTmpl : cancelBtnDefault"></ng-container>
                 </div>
                 <div (click)="setTime()">
                     <!--suppress HtmlUnknownAttribute -->
-                    <ng-container
-                        *ngTemplateOutlet="confirmBtnTmpl ? confirmBtnTmpl : confirmBtnDefault"></ng-container>
+                    <ng-container *ngTemplateOutlet="confirmBtnTmpl ? confirmBtnTmpl : confirmBtnDefault"></ng-container>
+                </div>
+                <div (click)="close()" *ngIf="reverseButtonOrder">
+                    <!--suppress HtmlUnknownAttribute -->
+                    <ng-container *ngTemplateOutlet="cancelBtnTmpl ? cancelBtnTmpl : cancelBtnDefault"></ng-container>
                 </div>
             </div>
         </div>
     </div>
 </div>
 <ng-template #cancelBtnDefault>
-    <ngx-material-timepicker-button>Cancel</ngx-material-timepicker-button>
+    <ngx-material-timepicker-button identifier="cancel">Cancel</ngx-material-timepicker-button>
 </ng-template>
 <ng-template #confirmBtnDefault>
-    <ngx-material-timepicker-button>Ok</ngx-material-timepicker-button>
+    <ngx-material-timepicker-button identifier="ok">OK</ngx-material-timepicker-button>
 </ng-template>

--- a/src/app/material-timepicker/ngx-material-timepicker.component.scss
+++ b/src/app/material-timepicker/ngx-material-timepicker.component.scss
@@ -47,7 +47,7 @@
         align-items: center;
         background-color: $body-background-color;
         @supports (background-color: var(--body-background-color)) {
-            background-color: var(--body-background-color)
+            background-color: var(--body-background-color);
         }
     }
     &__actions {
@@ -56,7 +56,7 @@
         padding: 15px;
         background-color: $body-background-color;
         @supports (background-color: var(--body-background-color)) {
-            background-color: var(--body-background-color)
+            background-color: var(--body-background-color);
         }
     }
 }
@@ -77,6 +77,18 @@
         &__actions {
             padding: 5px;
             margin-top: -1px;
+        }
+    }
+}
+
+// xs-breakpoint to fit iPhone 6 & 7
+@media (max-width: 599px) and (orientation: portrait) {
+    .timepicker {
+        &__header {
+            padding: 0px 30px;
+        }
+        &__actions {
+            padding: 0 15px 15px 15px;
         }
     }
 }

--- a/src/app/material-timepicker/ngx-material-timepicker.component.ts
+++ b/src/app/material-timepicker/ngx-material-timepicker.component.ts
@@ -25,12 +25,12 @@ const ESCAPE = 27;
     animations: [
         trigger('timepicker', [
             transition(`* => ${AnimationState.ENTER}`, [
-                style({transform: 'translateY(-30%)'}),
-                animate('0.2s ease-out', style({transform: 'translateY(0)'}))
+                style({ transform: 'translateY(-30%)' }),
+                animate('0.2s ease-out', style({ transform: 'translateY(0)' }))
             ]),
             transition(`${AnimationState.ENTER} => ${AnimationState.LEAVE}`, [
-                style({transform: 'translateY(0)', opacity: 1}),
-                animate('0.2s ease-out', style({transform: 'translateY(-30%)', opacity: 0}))
+                style({ transform: 'translateY(0)', opacity: 1 }),
+                animate('0.2s ease-out', style({ transform: 'translateY(-30%)', opacity: 0 }))
             ])
         ])
     ],
@@ -56,6 +56,7 @@ export class NgxMaterialTimepickerComponent implements OnInit, OnDestroy {
     @Input() enableKeyboardInput: boolean;
     @Input() preventOverlayClick: boolean;
     @Input() disableAnimation: boolean;
+    @Input() reverseButtonOrder = false;
 
     @Input()
     set format(value: number) {
@@ -95,7 +96,7 @@ export class NgxMaterialTimepickerComponent implements OnInit, OnDestroy {
     private subscriptions: Subscription[] = [];
 
     constructor(private timepickerService: NgxMaterialTimepickerService,
-                private eventService: NgxMaterialTimepickerEventService) {
+        private eventService: NgxMaterialTimepickerEventService) {
 
         this.subscriptions.push(merge(this.eventService.backdropClick,
             this.eventService.keydownEvent.pipe(filter(e => e.keyCode === ESCAPE && this.isEsc)))


### PR DESCRIPTION
I love this library. It is so well written :)

I had an issue displaying the time-picker on iPhone 6 and iPhone 7. The size of the clock was bigger than the screen width. 

To fix this issue I added an xs media query which only applies to devices under 599 pixels. The CSS renders a slightly smaller dial and removes some padding from the header and buttons to better fit the resolution.

I hope you like my change. Please ask any questions. I would love to see these changes included in your project.