### PR TITLE
fix: your minutes (NaN) doesnt match your minutesGap when no time picked.

### DIFF
--- a/src/app/material-timepicker/services/time-adapter.ts
+++ b/src/app/material-timepicker/services/time-adapter.ts
@@ -7,7 +7,6 @@ import { TimeOptions } from '../models/time-options.interface';
 
 // @dynamic
 export class TimeAdapter {
-
     static DEFAULT_FORMAT = 12;
     static DEFAULT_LOCALE = 'en-US';
 
@@ -42,7 +41,6 @@ export class TimeAdapter {
         minutesGap?: number,
         format?: number
     ): boolean {
-
         if (!time) {
             return;
         }
@@ -50,7 +48,7 @@ export class TimeAdapter {
         const convertedTime = this.parseTime(time, {format});
         const minutes = convertedTime.minute;
 
-        if (minutesGap && (minutes % minutesGap !== 0)) {
+        if (minutesGap && minutes === minutes && minutes % minutesGap !== 0) {
             throw new Error(`Your minutes - ${minutes} doesn\'t match your minutesGap - ${minutesGap}`);
         }
         const isAfter = (min && !max)


### PR DESCRIPTION
Timepicker would throw a minutesGap error while it should not, since there's no actual value to compare to the gap.

bug repro:
no default value, minutesGap set to 5.
open modal, cancel without setting a value.