### PR TITLE
directive error when value is undefined

### DIFF
--- a/src/app/material-timepicker/directives/ngx-timepicker.directive.spec.ts
+++ b/src/app/material-timepicker/directives/ngx-timepicker.directive.spec.ts
@@ -223,6 +223,14 @@ describe('TimepickerDirective', () => {
         expect(timepickerComponent.defaultTime).toBe(time);
     });
 
+    it('should not change default time when writeValue called with undefined', () => {
+        directive.timepicker = timepickerComponent;
+
+        directive.writeValue(undefined);
+        expect(directive.value).toBe('');
+        expect(timepickerComponent.defaultTime).toBeUndefined();
+    });
+
     it('should set onChange function on registerOnChange', () => {
         directive.timepicker = timepickerComponent;
         const spy = spyOn(console, 'log');

--- a/src/app/material-timepicker/directives/ngx-timepicker.directive.ts
+++ b/src/app/material-timepicker/directives/ngx-timepicker.directive.ts
@@ -154,7 +154,9 @@ export class TimepickerDirective implements ControlValueAccessor, OnDestroy, OnC
 
     writeValue(value: string): void {
         this.value = value;
-        this.defaultTime = value;
+        if (value) {
+            this.defaultTime = value;
+        }
     }
 
     registerOnChange(fn: (value: any) => void): void {


### PR DESCRIPTION
When a undefined value is set into directive `TimeAdapter.formatTime` throw an error