### PR TITLE
Support SSR by changing types to any

### DIFF
--- a/src/app/material-timepicker/components/ngx-material-timepicker-container/ngx-material-timepicker-container.component.ts
+++ b/src/app/material-timepicker/components/ngx-material-timepicker-container/ngx-material-timepicker-container.component.ts
@@ -82,7 +82,7 @@ export class NgxMaterialTimepickerContainerComponent implements OnInit, OnDestro
     }
 
     @HostListener('keydown', ['$event'])
-    onKeydown(e: KeyboardEvent): void {
+    onKeydown(e: any): void {
         this.eventService.dispatchEvent(e);
         e.stopPropagation();
     }

--- a/src/app/material-timepicker/components/timepicker-dial-control/ngx-material-timepicker-dial-control.component.ts
+++ b/src/app/material-timepicker/components/timepicker-dial-control/ngx-material-timepicker-dial-control.component.ts
@@ -51,7 +51,7 @@ export class NgxMaterialTimepickerDialControlComponent {
         }
     }
 
-    onKeyDown(e: KeyboardEvent): void {
+    onKeyDown(e: any): void {
         const char = String.fromCharCode(e.keyCode);
 
 

--- a/src/app/material-timepicker/components/timepicker-face/ngx-material-timepicker-face.component.ts
+++ b/src/app/material-timepicker/components/timepicker-face/ngx-material-timepicker-face.component.ts
@@ -84,7 +84,7 @@ export class NgxMaterialTimepickerFaceComponent implements AfterViewInit, OnChan
     }
 
     @HostListener('mousedown', ['$event'])
-    onMousedown(e: MouseEvent | TouchEvent) {
+    onMousedown(e: any) {
         e.preventDefault();
         this.isStarted = true;
     }
@@ -93,7 +93,7 @@ export class NgxMaterialTimepickerFaceComponent implements AfterViewInit, OnChan
     @HostListener('touchmove', ['$event.changedTouches[0]'])
     @HostListener('touchend', ['$event.changedTouches[0]'])
     @HostListener('mousemove', ['$event'])
-    selectTime(e: MouseEvent | Touch): void {
+    selectTime(e: any): void {
 
         if (!this.isStarted && (e instanceof MouseEvent && e.type !== 'click')) {
             return;
@@ -128,7 +128,7 @@ export class NgxMaterialTimepickerFaceComponent implements AfterViewInit, OnChan
     }
 
     @HostListener('mouseup', ['$event'])
-    onMouseup(e: MouseEvent | TouchEvent) {
+    onMouseup(e: any) {
         e.preventDefault();
         this.isStarted = false;
     }

--- a/src/app/material-timepicker/components/timepicker-field/timepicker-time-control/ngx-timepicker-time-control.component.ts
+++ b/src/app/material-timepicker/components/timepicker-field/timepicker-time-control/ngx-timepicker-time-control.component.ts
@@ -45,7 +45,7 @@ export class NgxTimepickerTimeControlComponent implements OnInit, OnChanges {
         }
     }
 
-    onKeydown(event: KeyboardEvent): void {
+    onKeydown(event: any): void {
         if (!isDigit(event)) {
             event.preventDefault();
         }

--- a/src/app/material-timepicker/directives/overlay.directive.ts
+++ b/src/app/material-timepicker/directives/overlay.directive.ts
@@ -13,7 +13,7 @@ export class OverlayDirective {
 
 
     @HostListener('click', ['$event'])
-    onClick(e: MouseEvent) {
+    onClick(e: any) {
         if (!this.preventClick) {
             this.eventService.dispatchEvent(e);
         }


### PR DESCRIPTION
KyeboardEvent, MouseEvent and TouchEvent are not correctly supported by SSR. 

To prevent errors like "ReferenceError: KeyboardEvent is not defined" it's better to use "any" type.