### PR TITLE
feat: add Output for anytime time changes

### DIFF
--- a/src/app/material-timepicker/components/ngx-material-timepicker-container/ngx-material-timepicker-container.component.spec.ts
+++ b/src/app/material-timepicker/components/ngx-material-timepicker-container/ngx-material-timepicker-container.component.spec.ts
@@ -1,15 +1,15 @@
-import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 
-import {AnimationState, NgxMaterialTimepickerContainerComponent} from './ngx-material-timepicker-container.component';
-import {Component, EventEmitter, NO_ERRORS_SCHEMA, Output} from '@angular/core';
-import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import {TimepickerRef} from '../../models/timepicker-ref.interface';
-import {of, Subject} from 'rxjs';
-import {DateTime} from 'luxon';
-import {TimeUnit} from '../../models/time-unit.enum';
-import {TimePeriod} from '../../models/time-period.enum';
-import {ClockFaceTime} from '../../models/clock-face-time.interface';
-import {NgxMaterialTimepickerEventService} from '../../services/ngx-material-timepicker-event.service';
+import { AnimationState, NgxMaterialTimepickerContainerComponent } from './ngx-material-timepicker-container.component';
+import { Component, EventEmitter, NO_ERRORS_SCHEMA, Output } from '@angular/core';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { TimepickerRef } from '../../models/timepicker-ref.interface';
+import { of, Subject } from 'rxjs';
+import { DateTime } from 'luxon';
+import { TimeUnit } from '../../models/time-unit.enum';
+import { TimePeriod } from '../../models/time-period.enum';
+import { ClockFaceTime } from '../../models/clock-face-time.interface';
+import { NgxMaterialTimepickerEventService } from '../../services/ngx-material-timepicker-event.service';
 
 @Component({
     template: ''

--- a/src/app/material-timepicker/components/ngx-material-timepicker-container/ngx-material-timepicker-container.component.spec.ts
+++ b/src/app/material-timepicker/components/ngx-material-timepicker-container/ngx-material-timepicker-container.component.spec.ts
@@ -1,15 +1,15 @@
-import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 
-import { AnimationState, NgxMaterialTimepickerContainerComponent } from './ngx-material-timepicker-container.component';
-import { Component, EventEmitter, NO_ERRORS_SCHEMA, Output } from '@angular/core';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { TimepickerRef } from '../../models/timepicker-ref.interface';
-import { of, Subject } from 'rxjs';
-import { DateTime } from 'luxon';
-import { TimeUnit } from '../../models/time-unit.enum';
-import { TimePeriod } from '../../models/time-period.enum';
-import { ClockFaceTime } from '../../models/clock-face-time.interface';
-import { NgxMaterialTimepickerEventService } from '../../services/ngx-material-timepicker-event.service';
+import {AnimationState, NgxMaterialTimepickerContainerComponent} from './ngx-material-timepicker-container.component';
+import {Component, EventEmitter, NO_ERRORS_SCHEMA, Output} from '@angular/core';
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+import {TimepickerRef} from '../../models/timepicker-ref.interface';
+import {of, Subject} from 'rxjs';
+import {DateTime} from 'luxon';
+import {TimeUnit} from '../../models/time-unit.enum';
+import {TimePeriod} from '../../models/time-period.enum';
+import {ClockFaceTime} from '../../models/clock-face-time.interface';
+import {NgxMaterialTimepickerEventService} from '../../services/ngx-material-timepicker-event.service';
 
 @Component({
     template: ''
@@ -19,6 +19,7 @@ class TimepickerBaseRefStub implements TimepickerRef {
 
     @Output() hourSelected = new EventEmitter<number>();
     @Output() timeSet = new EventEmitter<string>();
+    @Output() timeChanged = new EventEmitter<string>();
 
     close(): void {
     }
@@ -160,6 +161,15 @@ describe('NgxMaterialTimepickerContainerComponent', () => {
 
             tick();
         }));
+
+        it('should update timeChanged when hour is changed', fakeAsync(() => {
+            const expectedHour: ClockFaceTime = {time: 10, angle: 130};
+
+            component.timepickerBaseRef.timeChanged.subscribe(time => expect(time).toEqual('10:00 AM'));
+            component.onHourChange(expectedHour);
+
+            tick();
+        }));
     });
 
     describe('onMinuteChange', () => {
@@ -169,6 +179,15 @@ describe('NgxMaterialTimepickerContainerComponent', () => {
 
             component.onMinuteChange(expectedMinute);
             component.selectedMinute.subscribe(minute => expect(minute).toEqual(expectedMinute));
+
+            tick();
+        }));
+
+        it('should update timeChanged when minute is changed', fakeAsync(() => {
+            const expectedMinute: ClockFaceTime = {time: 10, angle: 130};
+
+            component.timepickerBaseRef.timeChanged.subscribe(time => expect(time).toEqual('12:10 PM'));
+            component.onMinuteChange(expectedMinute);
 
             tick();
         }));
@@ -184,6 +203,7 @@ describe('NgxMaterialTimepickerContainerComponent', () => {
 
             tick();
         }));
+
     });
 
     describe('onHourSelected', () => {

--- a/src/app/material-timepicker/components/ngx-material-timepicker-container/ngx-material-timepicker-container.component.ts
+++ b/src/app/material-timepicker/components/ngx-material-timepicker-container/ngx-material-timepicker-container.component.ts
@@ -108,6 +108,7 @@ export class NgxMaterialTimepickerContainerComponent implements OnInit, OnDestro
 
     onHourChange(hour: ClockFaceTime): void {
         this.timepickerService.hour = hour;
+        this.timepickerBaseRef.timeChanged.next(this.timepickerService.getFullTime(this.format));
     }
 
     onHourSelected(hour: number): void {
@@ -119,10 +120,12 @@ export class NgxMaterialTimepickerContainerComponent implements OnInit, OnDestro
 
     onMinuteChange(minute: ClockFaceTime): void {
         this.timepickerService.minute = minute;
+        this.timepickerBaseRef.timeChanged.next(this.timepickerService.getFullTime(this.format));
     }
 
     changePeriod(period: TimePeriod): void {
         this.timepickerService.period = period;
+        this.timepickerBaseRef.timeChanged.next(this.timepickerService.getFullTime(this.format));
     }
 
     changeTimeUnit(unit: TimeUnit): void {

--- a/src/app/material-timepicker/models/timepicker-ref.interface.ts
+++ b/src/app/material-timepicker/models/timepicker-ref.interface.ts
@@ -5,6 +5,7 @@ export interface TimepickerRef {
     timeSet: EventEmitter<string>;
     hourSelected: EventEmitter<number>;
     timeUpdated: Observable<string>;
+    timeChanged: EventEmitter<string>;
 
     close(): void;
 }

--- a/src/app/material-timepicker/ngx-material-timepicker.component.ts
+++ b/src/app/material-timepicker/ngx-material-timepicker.component.ts
@@ -1,16 +1,13 @@
-import { Component, EventEmitter, Input, Output, TemplateRef } from '@angular/core';
-import { merge, Subject } from 'rxjs';
-import { NgxMaterialTimepickerEventService } from './services/ngx-material-timepicker-event.service';
-import { filter, takeUntil } from 'rxjs/operators';
-import { TimepickerDirective } from './directives/ngx-timepicker.directive';
-import { DateTime } from 'luxon';
-import { DomService } from './services/dom.service';
-import {
-    NgxMaterialTimepickerContainerComponent
-} from './components/ngx-material-timepicker-container/ngx-material-timepicker-container.component';
-import { TimepickerRef } from './models/timepicker-ref.interface';
-import { NgxMaterialTimepickerTheme } from './models/ngx-material-timepicker-theme.interface';
-
+import {Component, EventEmitter, Input, Output, TemplateRef} from '@angular/core';
+import {merge, Subject} from 'rxjs';
+import {NgxMaterialTimepickerEventService} from './services/ngx-material-timepicker-event.service';
+import {filter, takeUntil} from 'rxjs/operators';
+import {TimepickerDirective} from './directives/ngx-timepicker.directive';
+import {DateTime} from 'luxon';
+import {DomService} from './services/dom.service';
+import {NgxMaterialTimepickerContainerComponent} from './components/ngx-material-timepicker-container/ngx-material-timepicker-container.component';
+import {TimepickerRef} from './models/timepicker-ref.interface';
+import {NgxMaterialTimepickerTheme} from './models/ngx-material-timepicker-theme.interface';
 
 const ESCAPE = 27;
 
@@ -69,6 +66,7 @@ export class NgxMaterialTimepickerComponent implements TimepickerRef {
     @Output() opened = new EventEmitter<null>();
     @Output() closed = new EventEmitter<null>();
     @Output() hourSelected = new EventEmitter<number>();
+    @Output() timeChanged = new EventEmitter<string>();
 
     private _minutesGap: number;
     private _format: number;

--- a/src/app/material-timepicker/ngx-material-timepicker.component.ts
+++ b/src/app/material-timepicker/ngx-material-timepicker.component.ts
@@ -1,15 +1,15 @@
-import {Component, EventEmitter, Input, Output, TemplateRef} from '@angular/core';
-import {merge, Subject} from 'rxjs';
-import {NgxMaterialTimepickerEventService} from './services/ngx-material-timepicker-event.service';
-import {filter, takeUntil} from 'rxjs/operators';
-import {TimepickerDirective} from './directives/ngx-timepicker.directive';
-import {DateTime} from 'luxon';
-import {DomService} from './services/dom.service';
+import { Component, EventEmitter, Input, Output, TemplateRef } from '@angular/core';
+import { merge, Subject } from 'rxjs';
+import { NgxMaterialTimepickerEventService } from './services/ngx-material-timepicker-event.service';
+import { filter, takeUntil } from 'rxjs/operators';
+import { TimepickerDirective } from './directives/ngx-timepicker.directive';
+import { DateTime } from 'luxon';
+import { DomService } from './services/dom.service';
 import {
     NgxMaterialTimepickerContainerComponent
 } from './components/ngx-material-timepicker-container/ngx-material-timepicker-container.component';
-import {TimepickerRef} from './models/timepicker-ref.interface';
-import {NgxMaterialTimepickerTheme} from './models/ngx-material-timepicker-theme.interface';
+import { TimepickerRef } from './models/timepicker-ref.interface';
+import { NgxMaterialTimepickerTheme } from './models/ngx-material-timepicker-theme.interface';
 
 const ESCAPE = 27;
 

--- a/src/app/material-timepicker/ngx-material-timepicker.component.ts
+++ b/src/app/material-timepicker/ngx-material-timepicker.component.ts
@@ -5,7 +5,9 @@ import {filter, takeUntil} from 'rxjs/operators';
 import {TimepickerDirective} from './directives/ngx-timepicker.directive';
 import {DateTime} from 'luxon';
 import {DomService} from './services/dom.service';
-import {NgxMaterialTimepickerContainerComponent} from './components/ngx-material-timepicker-container/ngx-material-timepicker-container.component';
+import {
+    NgxMaterialTimepickerContainerComponent
+} from './components/ngx-material-timepicker-container/ngx-material-timepicker-container.component';
 import {TimepickerRef} from './models/timepicker-ref.interface';
 import {NgxMaterialTimepickerTheme} from './models/ngx-material-timepicker-theme.interface';
 

--- a/src/app/material-timepicker/ngx-material-timepicker.module.ts
+++ b/src/app/material-timepicker/ngx-material-timepicker.module.ts
@@ -44,6 +44,7 @@ import {
     NgxMaterialTimepickerContentComponent
 } from './components/ngx-material-timepicker-content/ngx-material-timepicker-content.component';
 import { AppendToInputDirective } from './directives/append-to-input.directive';
+import {NgxMaterialTimepickerService} from './services/ngx-material-timepicker.service';
 
 
 @NgModule({
@@ -89,7 +90,8 @@ import { AppendToInputDirective } from './directives/append-to-input.directive';
         AppendToInputDirective
     ],
     providers: [
-        {provide: TIME_LOCALE, useValue: TimeAdapter.DEFAULT_LOCALE}
+        {provide: TIME_LOCALE, useValue: TimeAdapter.DEFAULT_LOCALE},
+        NgxMaterialTimepickerService
     ],
     entryComponents: [NgxMaterialTimepickerContainerComponent]
 })


### PR DESCRIPTION
Creates an @Output on the ngx-material-timepicker component to allow listening to all changes of the timepicker as they are happening rather than on Ok click.