### PR TITLE
ngx-material-field touch property was not working

### DIFF
--- a/src/app/material-timepicker/components/timepicker-field/ngx-timepicker-field.component.html
+++ b/src/app/material-timepicker/components/timepicker-field/ngx-timepicker-field.component.html
@@ -8,6 +8,7 @@
         [timeUnit]="timeUnit.HOUR"
         [disabled]="disabled"
         [isDefaultTimeSet]="isDefaultTime"
+        (click)="onTouched()"
         (timeChanged)="changeHour($event)"></ngx-timepicker-time-control>
     <span class="ngx-timepicker__time-colon ngx-timepicker__control--second">:</span>
     <ngx-timepicker-time-control
@@ -18,18 +19,21 @@
         [max]="59"
         [timeUnit]="timeUnit.MINUTE"
         [disabled]="disabled"
+        (click)="onTouched()"
         [isDefaultTimeSet]="isDefaultTime"
         (timeChanged)="changeMinute($event)"></ngx-timepicker-time-control>
     <ngx-timepicker-period-selector
         class="ngx-timepicker__control--forth"
         [selectedPeriod]="period$|async"
         [disabled]="disabled"
+        (click)="onTouched()"
         (periodSelected)="changePeriod($event)"
         *ngIf="format !== 24"></ngx-timepicker-period-selector>
     <ngx-material-timepicker-toggle
         class="ngx-timepicker__toggle"
         *ngIf="!controlOnly"
         [ngClass]="{'ngx-timepicker__toggle--left': buttonAlign === 'left'}"
+        (click)="onTouched()"
         [for]="timepicker"
         [disabled]="disabled">
         <span ngxMaterialTimepickerToggleIcon>
@@ -43,6 +47,7 @@
     [defaultTime]="timepickerTime"
     [format]="format"
     [cancelBtnTmpl]="cancelBtnTmpl"
+    (click)="onTouched()"
     [confirmBtnTmpl]="confirmBtnTmpl"
     (timeSet)="onTimeSet($event)" #timepicker></ngx-material-timepicker>
 

--- a/src/app/material-timepicker/components/timepicker-field/ngx-timepicker-field.component.ts
+++ b/src/app/material-timepicker/components/timepicker-field/ngx-timepicker-field.component.ts
@@ -87,6 +87,7 @@ export class NgxTimepickerFieldComponent implements OnInit, OnDestroy, ControlVa
 
     private onChange: (value: string) => void = () => {
     }
+    private onTouched: () => void = () => {}
 
     constructor(private timepickerService: NgxMaterialTimepickerService,
                 @Inject(TIME_LOCALE) private locale: string) {
@@ -110,6 +111,7 @@ export class NgxTimepickerFieldComponent implements OnInit, OnDestroy, ControlVa
     }
 
     registerOnTouched(fn: any): void {
+        this.onTouched();
     }
 
     registerOnChange(fn: any): void {


### PR DESCRIPTION
Fixed it by calling `onTouched` on each component of html. Otherwise if we apply it to wrapper div then `touched` property is getting set even though white space is clicked of ngx-timepicker-field.