### PR TITLE
add ability to show hint without keyboard

### DIFF
--- a/src/app/material-timepicker/components/timepicker-dial/ngx-material-timepicker-dial.component.html
+++ b/src/app/material-timepicker/components/timepicker-dial/ngx-material-timepicker-dial.component.html
@@ -31,7 +31,7 @@
                                         [meridiems]="meridiems"
                                         (periodChanged)="changePeriod($event)"></ngx-material-timepicker-period>
     </div>
-    <div *ngIf="isEditable" [ngClass]="{'timepicker-dial__hint-container--hidden': !isHintVisible}">
+    <div *ngIf="isEditable || editableHintTmpl" [ngClass]="{'timepicker-dial__hint-container--hidden': !isHintVisible}">
         <!--suppress HtmlUnknownAttribute -->
         <ng-container *ngTemplateOutlet="editableHintTmpl ? editableHintTmpl : editableHintDefault"></ng-container>
         <ng-template #editableHintDefault>


### PR DESCRIPTION
This PR allows you to show a hint below the timepicker, above the dial, even if you don't want the text to be editable.