### PR TITLE
Fix null reference error for invalid times

### DIFF
--- a/src/app/material-timepicker/services/time-adapter.ts
+++ b/src/app/material-timepicker/services/time-adapter.ts
@@ -25,7 +25,9 @@ export class TimeAdapter {
         }
         const {format} = opts;
         const parsedTime = TimeAdapter.parseTime(time, opts).setLocale(TimeAdapter.DEFAULT_LOCALE);
-
+        if (parsedTime.invalid) {
+            return null;
+        }
         if (format !== 24) {
             return parsedTime.toLocaleString({
                 ...DateTime.TIME_SIMPLE,


### PR DESCRIPTION
Prevents null reference error in parsedTime.toISOTime().replace() if parsedTime is invalid.

Fixes #349 