### PR TITLE
ngx-timepicker-field Missing defaultTime @Input()

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ Selector: `ngx-timepicker-field`
   min: string or DateTime | Set min time for timepicker (`11:15 pm` ) |
 | @Input()
   max: string or DateTime | Set max time for timepicker (`11:15 pm` ) |
+| @Input()
+  defaultTime: string | Set default time for a timepicker. |
 | @Output()
   timeChanged: EventEmitter\<string\> | Emit a new time once it is changed. |
 


### PR DESCRIPTION
The examples at https://agranom.github.io/ngx-material-timepicker/ utilize the input property defaultTime on the ngx-timepicker-field element.

This property is missing on the readme file.