### PR TITLE
Fix Invalid DateTime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ testem.log
 # System Files
 .DS_Store
 Thumbs.db
+.vscode/launch.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "ngx-material-timepicker",
-    "version": "5.5.3",
+    "version": "5.5.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ngx-material-timepicker",
     "description": "Handy material design timepicker for angular",
-    "version": "5.5.3",
+    "version": "5.5.4",
     "license": "MIT",
     "author": "Vitalii Boiko <boyko330@gmail.com>",
     "keywords": [

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -278,7 +278,7 @@
     </main>
     <footer class="footer">
         <div class="container">
-            <p class="footer__version">Current version 5.5.3</p>
+            <p class="footer__version">Current version 5.5.4</p>
         </div>
     </footer>
 </div>

--- a/src/app/material-timepicker/components/timepicker-dial-control/ngx-material-timepicker-dial-control.component.spec.ts
+++ b/src/app/material-timepicker/components/timepicker-dial-control/ngx-material-timepicker-dial-control.component.spec.ts
@@ -4,7 +4,7 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { TimeUnit } from '../../models/time-unit.enum';
 import { TimeLocalizerPipe } from '../../pipes/time-localizer.pipe';
 import { TimeParserPipe } from '../../pipes/time-parser.pipe';
-import { TIME_LOCALE } from '../../tokens/time-locale.token';
+import { NUMBERING_SYSTEM, TIME_LOCALE } from '../../tokens/time-locale.token';
 import { DateTime } from 'luxon';
 import { TimepickerTimeUtils } from '../../utils/timepicker-time.utils';
 
@@ -21,7 +21,8 @@ describe('NgxMaterialTimepickerDialControlComponent', () => {
             ],
             providers: [
                 TimeParserPipe,
-                {provide: TIME_LOCALE, useValue: 'ar-AE'}
+                {provide: TIME_LOCALE, useValue: 'ar-AE'},
+                {provide: NUMBERING_SYSTEM, useValue: 'arab'},
             ],
             schemas: [NO_ERRORS_SCHEMA]
         }).createComponent(NgxMaterialTimepickerDialControlComponent);
@@ -177,7 +178,7 @@ describe('NgxMaterialTimepickerDialControlComponent', () => {
     describe('onModelChange', () => {
 
         it('should parse value and set it to time property', () => {
-            const unparsedTime = DateTime.fromObject({minute: 10, numberingSystem: 'arab'}).toFormat('m');
+            const unparsedTime = DateTime.fromObject({minute: 10, numberingSystem: 'arab', locale: 'ar-AE'}).toFormat('m');
             component.time = '5';
             component.timeUnit = TimeUnit.MINUTE;
 

--- a/src/app/material-timepicker/components/timepicker-field/timepicker-time-control/ngx-timepicker-time-control.component.spec.ts
+++ b/src/app/material-timepicker/components/timepicker-field/timepicker-time-control/ngx-timepicker-time-control.component.spec.ts
@@ -13,7 +13,7 @@ describe('NgxTimepickerTimeControlComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [NgxMaterialTimepickerModule.setLocale('ar-AE')],
+            imports: [NgxMaterialTimepickerModule.setOpts('ar-AE', 'arab')],
             providers: [
                 TimeParserPipe,
                 TimeFormatterPipe
@@ -299,7 +299,7 @@ describe('NgxTimepickerTimeControlComponent', () => {
     describe('onModelChange', () => {
 
         it('should parse value and set it to time property', () => {
-            const unparsedTime = DateTime.fromObject({minute: 10, numberingSystem: 'arab'}).toFormat('m');
+            const unparsedTime = DateTime.fromObject({minute: 10, numberingSystem: 'arab', locale: 'ar-AE'}).toFormat('m');
             component.time = 5;
             component.timeUnit = TimeUnit.MINUTE;
 

--- a/src/app/material-timepicker/ngx-material-timepicker.module.ts
+++ b/src/app/material-timepicker/ngx-material-timepicker.module.ts
@@ -32,7 +32,7 @@ import {
     NgxTimepickerPeriodSelectorComponent
 } from './components/timepicker-field/timepicker-period-selector/ngx-timepicker-period-selector.component';
 import { TimeLocalizerPipe } from './pipes/time-localizer.pipe';
-import { TIME_LOCALE } from './tokens/time-locale.token';
+import { NUMBERING_SYSTEM, TIME_LOCALE } from './tokens/time-locale.token';
 import { TimeParserPipe } from './pipes/time-parser.pipe';
 import { ActiveHourPipe } from './pipes/active-hour.pipe';
 import { ActiveMinutePipe } from './pipes/active-minute.pipe';
@@ -97,11 +97,12 @@ import { AppendToInputDirective } from './directives/append-to-input.directive';
 })
 export class NgxMaterialTimepickerModule {
 
-    static setLocale(locale: string): ModuleWithProviders<NgxMaterialTimepickerModule> {
+    static setOpts(locale: string, numberingSystem: string): ModuleWithProviders<NgxMaterialTimepickerModule> {
         return {
             ngModule: NgxMaterialTimepickerModule,
             providers: [
-                {provide: TIME_LOCALE, useValue: locale}
+                {provide: TIME_LOCALE, useValue: locale},
+                {provide: NUMBERING_SYSTEM, useValue: numberingSystem}
             ]
         };
     }

--- a/src/app/material-timepicker/pipes/time-parser.pipe.spec.ts
+++ b/src/app/material-timepicker/pipes/time-parser.pipe.spec.ts
@@ -4,7 +4,8 @@ import { DateTime } from 'luxon';
 
 describe('TimeParserPipe', () => {
     const locale = 'ar-AE';
-    const pipe = new TimeParserPipe(locale);
+    const numberingSystem = 'arab';
+    const pipe = new TimeParserPipe(locale, numberingSystem);
 
     it('should create an instance', () => {
         expect(pipe).toBeTruthy();

--- a/src/app/material-timepicker/pipes/time-parser.pipe.ts
+++ b/src/app/material-timepicker/pipes/time-parser.pipe.ts
@@ -32,7 +32,10 @@ export class TimeParserPipe implements PipeTransform {
     }
 
     private parseTime(time: string | number, format: string, timeMeasure: TimeMeasure): number {
-        const parsedTime = DateTime.fromFormat(String(time), format, {numberingSystem: this.numberingSystem, locale: this.locale})[timeMeasure];
+        const parsedTime = DateTime.fromFormat(String(time), format, {
+            numberingSystem: this.numberingSystem,
+            locale: this.locale
+        })[timeMeasure];
 
         if (!isNaN(parsedTime)) {
             return parsedTime;

--- a/src/app/material-timepicker/pipes/time-parser.pipe.ts
+++ b/src/app/material-timepicker/pipes/time-parser.pipe.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable, Pipe, PipeTransform } from '@angular/core';
-import { TIME_LOCALE } from '../tokens/time-locale.token';
+import { NUMBERING_SYSTEM, TIME_LOCALE } from '../tokens/time-locale.token';
 import { TimeUnit } from '../models/time-unit.enum';
 import { DateTime } from 'luxon';
 
@@ -11,10 +11,7 @@ type TimeMeasure = 'hour' | 'minute';
 @Injectable()
 export class TimeParserPipe implements PipeTransform {
 
-    private readonly numberingSystem: string;
-
-    constructor(@Inject(TIME_LOCALE) private locale: string) {
-        this.numberingSystem = DateTime.local().setLocale(this.locale).resolvedLocaleOpts().numberingSystem;
+    constructor(@Inject(TIME_LOCALE) private locale: string, @Inject(NUMBERING_SYSTEM) private numberingSystem: string) {
     }
 
     transform(time: string | number, timeUnit = TimeUnit.HOUR): number | string {
@@ -35,7 +32,7 @@ export class TimeParserPipe implements PipeTransform {
     }
 
     private parseTime(time: string | number, format: string, timeMeasure: TimeMeasure): number {
-        const parsedTime = DateTime.fromFormat(String(time), format, {numberingSystem: this.numberingSystem})[timeMeasure];
+        const parsedTime = DateTime.fromFormat(String(time), format, {numberingSystem: this.numberingSystem, locale: this.locale})[timeMeasure];
 
         if (!isNaN(parsedTime)) {
             return parsedTime;

--- a/src/app/material-timepicker/services/time-adapter.spec.ts
+++ b/src/app/material-timepicker/services/time-adapter.spec.ts
@@ -128,14 +128,14 @@ describe('TimeAdapter', () => {
             const expected = '١١:١١ ص';
             const actual = '11:11 am';
 
-            expect(TimeAdapter.toLocaleTimeString(actual, {locale: 'ar-AE'})).toBe(expected);
+            expect(TimeAdapter.toLocaleTimeString(actual, {numberingSystem: 'arab', locale: 'ar-AE'})).toBe(expected);
         });
 
         it('should convert provided time (en-US) to provided locale (ar-AE) in 24-hours format', () => {
             const expected = '٢١:١١';
             const actual = '21:11';
 
-            expect(TimeAdapter.toLocaleTimeString(actual, {locale: 'ar-AE', format: 24})).toBe(expected);
+            expect(TimeAdapter.toLocaleTimeString(actual, {numberingSystem: 'arab', locale: 'ar-AE', format: 24})).toBe(expected);
         });
     });
 

--- a/src/app/material-timepicker/services/time-adapter.ts
+++ b/src/app/material-timepicker/services/time-adapter.ts
@@ -45,7 +45,7 @@ export class TimeAdapter {
         const hourCycle = format === 24 ? 'h23' : 'h12';
         const timeFormat = {...DateTime.TIME_SIMPLE, hourCycle};
         const timeMask = (format === 24) ? TimeFormat.TWENTY_FOUR_SHORT : TimeFormat.TWELVE_SHORT;
-        let localOpts = { locale: opts.locale, numberingSystem: opts.numberingSystem, ...timeFormat };
+        const localOpts = { locale: opts.locale, numberingSystem: opts.numberingSystem, ...timeFormat };
         return DateTime.fromFormat(time, timeMask).setLocale(locale).toLocaleString(localOpts).replace(/\u202F/g, ' ');
     }
 

--- a/src/app/material-timepicker/services/time-adapter.ts
+++ b/src/app/material-timepicker/services/time-adapter.ts
@@ -31,13 +31,13 @@ export class TimeAdapter {
                 ...DateTime.TIME_SIMPLE,
                 hour12: format !== 24,
                 numberingSystem: TimeAdapter.DEFAULT_NUMBERING_SYSTEM
-            }).replace(/\u200E/g, '').replace(' ', ' ');
+            }).replace(/\u200E/g, '').replace(/\u202F/g, ' ');
         }
         return parsedTime.toISOTime({
             includeOffset: false,
             suppressMilliseconds: true,
             suppressSeconds: true
-        }).replace(/\u200E/g, '').replace(' ', ' ');
+        }).replace(/\u200E/g, '').replace(/\u202F/g, ' ');
     }
 
     static toLocaleTimeString(time: string, opts: TimeOptions = {}): string {

--- a/src/app/material-timepicker/services/time-adapter.ts
+++ b/src/app/material-timepicker/services/time-adapter.ts
@@ -31,13 +31,13 @@ export class TimeAdapter {
                 ...DateTime.TIME_SIMPLE,
                 hour12: format !== 24,
                 numberingSystem: TimeAdapter.DEFAULT_NUMBERING_SYSTEM
-            }).replace(/\u200E/g, '');
+            }).replace(/\u200E/g, '').replace(' ', ' ');
         }
         return parsedTime.toISOTime({
             includeOffset: false,
             suppressMilliseconds: true,
             suppressSeconds: true
-        }).replace(/\u200E/g, '');
+        }).replace(/\u200E/g, '').replace(' ', ' ');
     }
 
     static toLocaleTimeString(time: string, opts: TimeOptions = {}): string {

--- a/src/app/material-timepicker/services/time-adapter.ts
+++ b/src/app/material-timepicker/services/time-adapter.ts
@@ -45,8 +45,8 @@ export class TimeAdapter {
         const hourCycle = format === 24 ? 'h23' : 'h12';
         const timeFormat = {...DateTime.TIME_SIMPLE, hourCycle};
         const timeMask = (format === 24) ? TimeFormat.TWENTY_FOUR_SHORT : TimeFormat.TWELVE_SHORT;
-
-        return DateTime.fromFormat(time, timeMask).setLocale(locale).toLocaleString(timeFormat);
+        let localOpts = { locale: opts.locale, numberingSystem: opts.numberingSystem, ...timeFormat };
+        return DateTime.fromFormat(time, timeMask).setLocale(locale).toLocaleString(localOpts).replace(/\u202F/g, ' ');
     }
 
     static isTimeAvailable(
@@ -101,12 +101,11 @@ export class TimeAdapter {
         return time.reconfigure({
             numberingSystem: TimeAdapter.DEFAULT_NUMBERING_SYSTEM,
             locale: TimeAdapter.DEFAULT_LOCALE
-        }).toFormat(timeFormat);
+        }).toFormat(timeFormat).replace(/\u202F/g, ' ');
     }
 
     private static getLocaleOptionsByTime(time: string, opts: TimeOptions): LocaleOptions {
-        const {numberingSystem, locale} = DateTime.local().setLocale(opts.locale).resolvedLocaleOpts();
-        const localeConfig: LocaleOptions = {numberingSystem: numberingSystem, locale};
+        const localeConfig: LocaleOptions = {numberingSystem: opts.numberingSystem, locale: opts.locale};
         const defaultConfig: LocaleOptions = {numberingSystem: TimeAdapter.DEFAULT_NUMBERING_SYSTEM, locale: TimeAdapter.DEFAULT_LOCALE};
 
         return isNaN(parseInt(time, 10)) ? localeConfig : defaultConfig;

--- a/src/app/material-timepicker/tokens/time-locale.token.ts
+++ b/src/app/material-timepicker/tokens/time-locale.token.ts
@@ -5,3 +5,8 @@ export const TIME_LOCALE = new InjectionToken<string>('TimeLocale', {
     providedIn: 'root',
     factory: () => TimeAdapter.DEFAULT_LOCALE
 });
+
+export const NUMBERING_SYSTEM = new InjectionToken<string>('NumberingSystem', {
+    providedIn: 'root',
+    factory: () => TimeAdapter.DEFAULT_NUMBERING_SYSTEM
+});


### PR DESCRIPTION
The default numbering system "latn" used to parse the time in locale string returns a Narrow No-Break Space (NNBSP) instead of standard space which cause the parse to fail. The proposed fix replace the NNBSP for a standard space.