### PR TITLE
Allow TIME_LOCALE and NUMBERING_SYSTEM to be provided by applications directly

### DIFF
--- a/public_api.ts
+++ b/public_api.ts
@@ -9,3 +9,4 @@ export * from './src/app/material-timepicker/directives/ngx-timepicker.directive
 export * from './src/app/material-timepicker/ngx-material-timepicker.component';
 export * from './src/app/material-timepicker/components/timepicker-field/ngx-timepicker-field.component';
 export * from './src/app/material-timepicker/components/timepicker-toggle-button/ngx-material-timepicker-toggle.component';
+export { NUMBERING_SYSTEM, TIME_LOCALE } from './src/app/material-timepicker/tokens/time-locale.token';


### PR DESCRIPTION
Making TIME_LOCALE and NUMBERING_SYSTEM part of the public api allow consuming applications to provide such values by themselves instead of using `NgxMaterialTimepickerModule.setOpts()`.

That allows a more dynamic approach where values can be loaded from configuration first using APP_INITIALIZER and then set with a factory provider.

It's also aligned with Angular's LOCALE_ID

#409 